### PR TITLE
Increasing build. 

### DIFF
--- a/bin/everblog
+++ b/bin/everblog
@@ -12,6 +12,8 @@ const open = require('open')
 const chalk = require('chalk')
 const yaml = require('js-yaml')
 const program = require('commander')
+const moment = require('moment')
+const deepcopy = require("deepcopy");
 
 const utils = require('../lib/utils')
 const pkg = require('../package.json')
@@ -74,6 +76,12 @@ function buildBlog() {
     return Promise.reject()
   }
 
+  config.lastBuild = (new Date(config.lastBuild)).getTime()
+  if (!config.lastBuild) {
+    config.lastBuild = 0
+  } 
+
+
   let buildProcessor
   try {
     buildProcessor = require(dir)
@@ -95,6 +103,9 @@ function buildBlog() {
     return yield buildProcessor(data)
   }).then(() => {
     log('build finished')
+    let newConfig = deepcopy(config)
+    newConfig.lastBuild = moment().format('YYYY-MM-DD HH:mm:ss')
+    fs.writeFileSync(configPath, yaml.safeDump(newConfig))
   }).catch(e => {
     error(e.stack || e)
     return Promise.reject()

--- a/bin/everblog
+++ b/bin/everblog
@@ -13,7 +13,6 @@ const chalk = require('chalk')
 const yaml = require('js-yaml')
 const program = require('commander')
 const moment = require('moment')
-const deepcopy = require("deepcopy");
 
 const utils = require('../lib/utils')
 const pkg = require('../package.json')
@@ -103,7 +102,7 @@ function buildBlog() {
     return yield buildProcessor(data)
   }).then(() => {
     log('build finished')
-    let newConfig = deepcopy(config)
+    let newConfig = _.cloneDeep(config)
     newConfig.lastBuild = moment().format('YYYY-MM-DD HH:mm:ss')
     fs.writeFileSync(configPath, yaml.safeDump(newConfig))
   }).catch(e => {

--- a/lib/everblog.js
+++ b/lib/everblog.js
@@ -42,6 +42,10 @@ module.exports = class EverblogCore {
 
     let notes = (yield this._findNotes(_filter, _offset, _maxNotes)).notes
     notes = yield notes.map(function* (note) {
+      // no update from last everblog build
+      if (note.updated < this._options.lastBuild) {
+        return undefined
+      }
       note.content = yield this._getNoteContent(note.guid)
       // not share _config.yml
       if (note.title.trim() !== '_config.yml') {
@@ -54,6 +58,9 @@ module.exports = class EverblogCore {
       }
       return note
     }, this)
+
+    // filter out all undefined members
+    notes = notes.filter((note) => {return note})
 
     _notes = _notes.concat(notes)
     _offset = _offset + _maxNotes

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "co": "^4.6.0",
     "commander": "^2.9.0",
     "debug": "^2.2.0",
+    "deepcopy": "^0.6.3",
     "enml2text": "^0.1.1",
     "entities": "^1.1.1",
     "evernote": "^1.25.82",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "co": "^4.6.0",
     "commander": "^2.9.0",
     "debug": "^2.2.0",
-    "deepcopy": "^0.6.3",
     "enml2text": "^0.1.1",
     "entities": "^1.1.1",
     "evernote": "^1.25.82",


### PR DESCRIPTION
Don't export all notest and only export the notes updated after last build. If you want to export all notes once again, just delete the line of lastBuild field in .everblogrc.